### PR TITLE
Fix trusted-publishing CI guard check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,13 @@ jobs:
           set -euo pipefail
           test -f .github/workflows/publish-testpypi.yml
           test -f .github/workflows/release.yml
-          grep -Eq 'id-token:[[:space:]]*write' .github/workflows/publish-testpypi.yml
-          grep -Eq 'id-token:[[:space:]]*write' .github/workflows/release.yml
-          grep -Eq 'gh-action-pypi-publish@' .github/workflows/publish-testpypi.yml
-          grep -Eq 'gh-action-pypi-publish@' .github/workflows/release.yml
-          grep -Eq 'repository-url:[[:space:]]*https://test\\.pypi\\.org/legacy/' .github/workflows/publish-testpypi.yml
+          grep -Fq 'name: test' .github/workflows/publish-testpypi.yml
+          grep -Fq 'name: release' .github/workflows/release.yml
+          grep -Fq 'id-token: write' .github/workflows/publish-testpypi.yml
+          grep -Fq 'id-token: write' .github/workflows/release.yml
+          grep -Fq 'gh-action-pypi-publish@' .github/workflows/publish-testpypi.yml
+          grep -Fq 'gh-action-pypi-publish@' .github/workflows/release.yml
+          grep -Fq 'repository-url: https://test.pypi.org/legacy/' .github/workflows/publish-testpypi.yml
 
   test:
     needs: trusted-publishing-config


### PR DESCRIPTION
## Why
`trusted-publishing-config` failed repeatedly on main while validating workflow guardrails. The previous check used regex grep assertions that were brittle in the runner shell.

## What changed
- switched guard checks in `.github/workflows/ci.yml` from regex to fixed-string (`grep -Fq`) checks
- added explicit environment-name assertions for trusted publisher alignment:
  - `publish-testpypi.yml` uses `name: test`
  - `release.yml` uses `name: release`

## Security impact
- keeps the guardrail in place (does not remove it)
- no secrets introduced
- continues validating OIDC publishing prerequisites (`id-token: write`, `gh-action-pypi-publish`, TestPyPI URL)
