### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skill-scanner"
-version = "0.1.1"
+version = "0.1.2"
 description = "Security scanner for AI agent skills and instruction artifacts"
 readme = "README.md"
 authors = [{ name = "skill-scanner" }]

--- a/src/skill_scanner/__init__.py
+++ b/src/skill_scanner/__init__.py
@@ -1,4 +1,4 @@
 """skill_scanner package."""
 
 __all__ = ["__version__"]
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/uv.lock
+++ b/uv.lock
@@ -1222,7 +1222,7 @@ wheels = [
 
 [[package]]
 name = "skill-scanner"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- bump package version from `0.1.1` to `0.1.2`
- update version in:
  - `pyproject.toml`
  - `src/skill_scanner/__init__.py`
  - `uv.lock`

## Validation
- `uv run pytest` (39 passed)
