### PR TITLE
fix: harden cross-platform discovery reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,29 @@ By default, `discover` and `scan` detect markdown-based skill/instruction artifa
 Validated skill locations also include:
 
 - Windsurf: `.windsurf/skills/*/SKILL.md`, `~/.codeium/windsurf/skills/*/SKILL.md`
-- Gemini CLI: `.gemini/skills/*/SKILL.md`, `~/.gemini/skills/*/SKILL.md`
-- Cline: `.cline/skills/*/SKILL.md`, `~/.cline/skills/*/SKILL.md`
-- OpenCode: `.opencode/skills/*/SKILL.md`, `~/.config/opencode/skills/*/SKILL.md`
+- Gemini CLI: `.gemini/skills/*/SKILL.md`, `~/.gemini/skills/*/SKILL.md` (`.agents/skills/*/SKILL.md` when `--platform gemini`)
+- Cline: `.cline/skills/*/SKILL.md`, `.clinerules/skills/*/SKILL.md`, `~/.cline/skills/*/SKILL.md`, `~/.clinerules/skills/*/SKILL.md`
+- OpenCode: `.opencode/skills/*/SKILL.md`, `~/.config/opencode/skills/*/SKILL.md` (`.agents/skills/*/SKILL.md` and `.claude/skills/*/SKILL.md` when `--platform opencode`)
 
 Use `--path` to target a specific file or folder.
+
+Default discover behavior:
+
+- `discover` attempts all scopes (`repo`, `user`, `system`, `extension`).
+- `repo` scope is only active when your current directory is inside a git repository.
+- Filesystem traversal errors are non-fatal; discovery returns partial results. Use `--verbose` to inspect warnings.
 
 ## Quick start
 
 ```bash
 # See targets
 uv run skill-scanner discover --format json
+
+# Discover only user scope
+uv run skill-scanner discover --scope user
+
+# Show detailed discovery warnings
+uv run skill-scanner discover --verbose
 
 # Verify key/model configuration
 uv run skill-scanner doctor
@@ -123,6 +135,12 @@ uv run skill-scanner scan --verbose --format summary
 # List discovered targets without running analyzers
 uv run skill-scanner scan --list-targets
 
+# Discover targets from user scope only
+uv run skill-scanner discover --scope user --format table
+
+# Discover with detailed traversal diagnostics
+uv run skill-scanner discover --verbose --format table
+
 # Scan only selected discovered targets (repeat --target)
 uv run skill-scanner scan --target /absolute/path/to/SKILL.md --target /absolute/path/to/AGENTS.md --format summary
 
@@ -137,6 +155,21 @@ uv run skill-scanner doctor --check --verbose
 ```
 
 `--list-targets` can be used without API keys because it only runs discovery and exits.
+
+## Discovery troubleshooting (macOS/Windows)
+
+```bash
+# macOS/Windows: default discover should complete without crashing
+uv run skill-scanner discover --format table
+
+# Scoped check: verify user skill paths only
+uv run skill-scanner discover --scope user --format table
+```
+
+Windows known-path sanity check:
+- create `%USERPROFILE%\\.clinerules\\skills\\demo\\SKILL.md`
+- run `uv run skill-scanner discover --platform cline --scope user --format table`
+- confirm the demo skill appears in output
 
 ## Exit behavior
 

--- a/src/skill_scanner/discovery/patterns.py
+++ b/src/skill_scanner/discovery/patterns.py
@@ -11,6 +11,7 @@ class DiscoveryPattern:
     scope: Scope
     glob: str
     kind: TargetKind
+    explicit_platform_only: bool = False
 
 
 REPO_PATTERNS: tuple[DiscoveryPattern, ...] = (
@@ -29,8 +30,30 @@ REPO_PATTERNS: tuple[DiscoveryPattern, ...] = (
     DiscoveryPattern(Platform.CURSOR, Scope.REPO, ".cursor/skills/*/SKILL.md", TargetKind.SKILL),
     DiscoveryPattern(Platform.WINDSURF, Scope.REPO, ".windsurf/skills/*/SKILL.md", TargetKind.SKILL),
     DiscoveryPattern(Platform.GEMINI, Scope.REPO, ".gemini/skills/*/SKILL.md", TargetKind.SKILL),
+    DiscoveryPattern(
+        Platform.GEMINI,
+        Scope.REPO,
+        ".agents/skills/*/SKILL.md",
+        TargetKind.SKILL,
+        explicit_platform_only=True,
+    ),
     DiscoveryPattern(Platform.CLINE, Scope.REPO, ".cline/skills/*/SKILL.md", TargetKind.SKILL),
+    DiscoveryPattern(Platform.CLINE, Scope.REPO, ".clinerules/skills/*/SKILL.md", TargetKind.SKILL),
     DiscoveryPattern(Platform.OPENCODE, Scope.REPO, ".opencode/skills/*/SKILL.md", TargetKind.SKILL),
+    DiscoveryPattern(
+        Platform.OPENCODE,
+        Scope.REPO,
+        ".agents/skills/*/SKILL.md",
+        TargetKind.SKILL,
+        explicit_platform_only=True,
+    ),
+    DiscoveryPattern(
+        Platform.OPENCODE,
+        Scope.REPO,
+        ".claude/skills/*/SKILL.md",
+        TargetKind.SKILL,
+        explicit_platform_only=True,
+    ),
     DiscoveryPattern(Platform.VSCODE, Scope.REPO, ".github/prompts/**/*.prompt.md", TargetKind.PROMPT),
     DiscoveryPattern(Platform.VSCODE, Scope.REPO, ".github/agents/**/*.agent.md", TargetKind.AGENT),
 )
@@ -45,8 +68,30 @@ USER_PATTERNS: tuple[DiscoveryPattern, ...] = (
     DiscoveryPattern(Platform.COPILOT, Scope.USER, ".copilot/skills/*/SKILL.md", TargetKind.SKILL),
     DiscoveryPattern(Platform.WINDSURF, Scope.USER, ".codeium/windsurf/skills/*/SKILL.md", TargetKind.SKILL),
     DiscoveryPattern(Platform.GEMINI, Scope.USER, ".gemini/skills/*/SKILL.md", TargetKind.SKILL),
+    DiscoveryPattern(
+        Platform.GEMINI,
+        Scope.USER,
+        ".agents/skills/*/SKILL.md",
+        TargetKind.SKILL,
+        explicit_platform_only=True,
+    ),
     DiscoveryPattern(Platform.CLINE, Scope.USER, ".cline/skills/*/SKILL.md", TargetKind.SKILL),
+    DiscoveryPattern(Platform.CLINE, Scope.USER, ".clinerules/skills/*/SKILL.md", TargetKind.SKILL),
     DiscoveryPattern(Platform.OPENCODE, Scope.USER, ".config/opencode/skills/*/SKILL.md", TargetKind.SKILL),
+    DiscoveryPattern(
+        Platform.OPENCODE,
+        Scope.USER,
+        ".agents/skills/*/SKILL.md",
+        TargetKind.SKILL,
+        explicit_platform_only=True,
+    ),
+    DiscoveryPattern(
+        Platform.OPENCODE,
+        Scope.USER,
+        ".claude/skills/*/SKILL.md",
+        TargetKind.SKILL,
+        explicit_platform_only=True,
+    ),
 )
 
 SYSTEM_PATTERNS: tuple[DiscoveryPattern, ...] = (
@@ -58,9 +103,9 @@ EXTENSION_PATTERNS: tuple[DiscoveryPattern, ...] = (
 )
 
 
-def matches_platform(requested: Platform, candidate: Platform) -> bool:
+def matches_platform(requested: Platform, candidate: Platform, explicit_platform_only: bool = False) -> bool:
     if requested == Platform.ALL:
-        return True
+        return not explicit_platform_only
     if requested == Platform.GENERIC:
         return True
     return requested == candidate


### PR DESCRIPTION
## Summary
- harden discovery traversal to handle filesystem errors non-fatally (glob/rglob/resolve/stat) and return partial results with warnings
- add discovery diagnostics support and wire `discover` to show warning counts/details via `--verbose`
- keep default all-scope discovery while making repo scope active only when CWD is inside a git repository
- add documented cross-platform pattern coverage updates: Cline `.clinerules`, and platform-specific shared-path aliases for Gemini/OpenCode without `--platform all` collisions
- update README with new discover behavior, flags, and macOS/Windows troubleshooting guidance

## CLI changes
- `skill-scanner discover` now supports `--scope` (repeatable)
- `skill-scanner discover` now supports `--verbose`

## Validation
- `uv run ruff check .`
- `uv run mypy src`
- `uv run pytest`
- manual macOS checks from `~` with project context:
  - `skill-scanner discover --format table` (no crash)
  - `skill-scanner discover --scope user --format table`
