### PR TITLE
feat: improve VT-driven AI signal quality + bump 0.1.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skill-scanner"
-version = "0.1.6"
+version = "0.1.7"
 description = "Security scanner for AI agent skills and instruction artifacts"
 readme = "README.md"
 authors = [{ name = "skill-scanner" }]

--- a/src/skill_scanner/models/reports.py
+++ b/src/skill_scanner/models/reports.py
@@ -30,6 +30,9 @@ class VTReport(BaseModel):
     suspicious: int = 0
     harmless: int = 0
     undetected: int = 0
+    analysis_total: int = 0
+    detection_ratio: float = 0.0
+    top_detections: list[str] = Field(default_factory=list)
     source: str = "virustotal"
     permalink: str | None = None
 

--- a/src/skill_scanner/output/summary.py
+++ b/src/skill_scanner/output/summary.py
@@ -77,9 +77,17 @@ def format_summary_report(report: ScanReport) -> str:
                 f"malicious={vt.malicious}, suspicious={vt.suspicious}, "
                 f"undetected={vt.undetected}, harmless={vt.harmless}"
             )
+            if vt.analysis_total > 0:
+                detected = vt.malicious + vt.suspicious
+                vt_line += f", detections={detected}/{vt.analysis_total} ({vt.detection_ratio * 100:.2f}%)"
             if vt.permalink:
                 vt_line += f" | {vt.permalink}"
             lines.append(vt_line)
+            if vt.top_detections:
+                sample = ", ".join(vt.top_detections[:3])
+                remaining = len(vt.top_detections) - 3
+                suffix = "" if remaining <= 0 else f", +{remaining} more"
+                lines.append(f"VirusTotal engines: {sample}{suffix}")
 
         if item.notes:
             lines.append("Notes:")

--- a/src/skill_scanner/providers/openai_provider.py
+++ b/src/skill_scanner/providers/openai_provider.py
@@ -16,6 +16,10 @@ Return strict JSON with key `findings` as a list of objects with:
 category,severity,title,description,file_path,line,recommendation,cwe.
 Valid severities: critical,high,medium,low,info.
 Valid categories: prompt_injection,data_exfiltration,hidden_commands,permission_escalation,supply_chain_risk,filesystem_attack,social_engineering,credential_harvesting,malformed_skill,configuration_risk.
+When `VIRUSTOTAL_CONTEXT` is present:
+- Use it as corroborating evidence to prioritize and adjust severity/confidence of file-backed findings.
+- Prefer findings that reference concrete risky content in the payload (`file_path` and `line` when possible).
+- Do not emit a standalone finding that only repeats VT verdict counts or permalink without additional file-level evidence.
 Do not return prose outside JSON.
 """.strip()
 

--- a/tests/test_ai_analyzer.py
+++ b/tests/test_ai_analyzer.py
@@ -65,10 +65,15 @@ def test_analyze_with_ai_includes_vt_context(tmp_path: Path) -> None:
         suspicious=0,
         harmless=0,
         undetected=5,
+        analysis_total=6,
+        detection_ratio=1 / 6,
         permalink="https://example.test/vt",
     )
 
     _, payload_result = asyncio.run(analyze_with_ai(target, provider, vt_report=vt_report))
     assert "## VIRUSTOTAL_CONTEXT" in provider.last_payload
+    assert "verdict: malicious" in provider.last_payload
+    assert "detections: 1/6" in provider.last_payload
+    assert "guidance: Use VT as corroborating evidence" in provider.last_payload
     assert "malicious: 1" in provider.last_payload
     assert payload_result.included_files == 1

--- a/tests/test_vt_analyzer.py
+++ b/tests/test_vt_analyzer.py
@@ -96,3 +96,30 @@ def test_scan_with_vt_surfaces_error_context(monkeypatch, tmp_path: Path) -> Non
     assert result.report is None
     assert result.error is not None
     assert "cache lookup failed" in result.error.lower()
+
+
+def test_parse_vt_file_includes_detection_ratio_and_top_engines() -> None:
+    parsed = vt_analyzer._parse_vt_file(
+        {
+            "data": {
+                "attributes": {
+                    "last_analysis_stats": {
+                        "malicious": 2,
+                        "suspicious": 1,
+                        "harmless": 4,
+                        "undetected": 3,
+                    },
+                    "last_analysis_results": {
+                        "EngineA": {"category": "malicious", "result": "Trojan.Generic"},
+                        "EngineB": {"category": "suspicious", "result": "Riskware"},
+                        "EngineC": {"category": "harmless", "result": "clean"},
+                    },
+                }
+            }
+        },
+        sha256="abc123",
+    )
+
+    assert parsed.analysis_total == 10
+    assert parsed.detection_ratio == 0.3
+    assert parsed.top_detections == ["EngineA: Trojan.Generic", "EngineB: Riskware"]

--- a/uv.lock
+++ b/uv.lock
@@ -1222,7 +1222,7 @@ wheels = [
 
 [[package]]
 name = "skill-scanner"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- enrich VirusTotal report model and parsing with detection ratio, analysis total, and top engine detections
- inject richer VT context into AI payload and prompt guidance to use VT as corroboration instead of standalone duplication
- add pipeline normalization to drop VT-only AI findings when they have no file-level evidence
- improve summary output with VT detection ratio and sampled detecting engines
- bump version to `0.1.7`

