### PR TITLE
chore(release): bump version to 0.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skill-scanner"
-version = "0.3.1"
+version = "0.3.2"
 description = "Security scanner for detecting and remediating malicious AI agent skills and instruction artifacts"
 readme = "README.md"
 authors = [{ name = "skill-scanner" }]

--- a/uv.lock
+++ b/uv.lock
@@ -1837,7 +1837,7 @@ wheels = [
 
 [[package]]
 name = "skill-scanner"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Bump package version to 0.3.2
- Regenerate uv.lock with the updated project version

## Test Plan
- uv lock
- uv sync --locked --group dev and ruff/mypy/pytest on Python 3.11, 3.12, 3.13
- uv build --no-sources